### PR TITLE
Fix missing version in the manual part of the package install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ rtimulib2-pypilot*
 python*
 rtimulib2/*
 !rtimulib2/debian
+rtimulib2/debian/files
+rtimulib2/debian/debhelper-build-stamp

--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ The used packaging tool here is **dh_make** and the packaging approach is **nati
 ## Create a debian package for rtimulib2 library 
 rtimulib2 is a wildly used and well established library. Pypilot have it's own flavour of it.It must not be confused or replaced with any other rtimulib lib.
 
-### Download rtimulib2
+### Download this repository 
+```
+git clone https://github.com/pypilot/pypilot-debian.git
+cd pypilot-debian
+```
+
+
+### Get rtimulib2 source code 
 ```
 wget https://github.com/seandepagnier/RTIMULib2/archive/master.zip
 unzip master.zip
 cp -r RTIMULib2-master/* rtimulib2/
-rm master.zip
+rm -r master.zip RTIMULib2-master
 ```
 
 ### Build the Package

--- a/rtimulib2/debian/changelog
+++ b/rtimulib2/debian/changelog
@@ -1,3 +1,9 @@
+rtimulib2-pypilot (0.0.11) focal; urgency=medium
+
+  * Fix code compiler destination to include rtimu version
+
+ -- Frederic Guilbault <2@0464.ca>  19 feb 2020 00:00:00 +0000
+
 rtimulib2-pypilot (0.0.10) focal; urgency=medium
 
   * Fix package name and deps

--- a/rtimulib2/debian/control
+++ b/rtimulib2/debian/control
@@ -10,7 +10,6 @@ Homepage: http://pypilot.org
 
 Package: python3-rtimulib2-pypilot
 Conflicts: python3-rtimulib
-Section: python, librtimulib7
 Architecture: any
 Depends: ${misc:Depends}, python3
 Description: Versatile C++ and Python 9-dof, 10-dof and 11-dof IMU library (Python 3)

--- a/rtimulib2/debian/files
+++ b/rtimulib2/debian/files
@@ -1,1 +1,0 @@
-rtimulib2-pypilot_0.0.10_source.buildinfo libs optional

--- a/rtimulib2/debian/rules
+++ b/rtimulib2/debian/rules
@@ -14,12 +14,12 @@ extra_flags += \
 
 # main packaging script based on dh7 syntax
 %:
-	dh $@ -D Linux --with python3
+	dh $@ --with python3
 
 override_dh_auto_configure:
 	dh_auto_configure -- $(extra_flags)
 
 override_dh_auto_install:
+	cd Linux/python && python2.7 setup.py install --root=../../debian/python2-rtimulib2-pypilot --install-layout=deb
+	cd Linux/python && python3 setup.py install --root=../../debian/python3-rtimulib2-pypilot --install-layout=deb
 	dh_auto_install
-	cd Linux/python && python2.7 setup.py install --root=../../debian/python2-rtimulib-pypilot --install-layout=deb
-	cd Linux/python && python3 setup.py install --root=../../debian/python3-rtimulib-pypilot --install-layout=deb


### PR DESCRIPTION
The missing version number was causing to create 4 packages instead of two, putting the python files in a different package than documentation and others control files. Now they are all in the same package.